### PR TITLE
deterministically shuffle rows in splitFiles.py

### DIFF
--- a/test_syndiffix/misc/splitFiles.py
+++ b/test_syndiffix/misc/splitFiles.py
@@ -2,6 +2,7 @@ import os
 import sys
 sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 import pandas as pd
+import numpy as np
 import pprint
 import fire
 
@@ -35,12 +36,15 @@ def splitFiles():
         print(f"Number of rows: {df.shape[0]}")
         print("Before shuffle:")
         print(df.head())
+
+        np.random.seed(0)
         dfShuffled = df.sample(frac=1)
+
         print("After shuffle:")
         print(dfShuffled.head())
         half = int(dfShuffled.shape[0] / 2)
-        df1 = df[:half]
-        df2 = df[half:]
+        df1 = dfShuffled[:half]
+        df2 = dfShuffled[half:]
         print(f"Length of two splits: {df1.shape[0]}, {df2.shape[0]}")
         path1 = os.path.join(outDir1, csvFile)
         df1.to_csv(path1, index=False, header=df.columns)


### PR DESCRIPTION
Tiny fix I did when figuring out the entire privacy measuring stack.

I think that we should use the shuffled DF when splitting (I'm assuming ignoring the shuffled DF wasn't intended), and also that we can shuffle and split deterministically without loss of correctness.