### PR TITLE
Privacy pipeline fixes - boolean dtype

### DIFF
--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -143,7 +143,7 @@ def makeMetadata(df):
     return metadata
 
 
-def oneModel(dataDir='csvGeneral', dataSourceNum=0, model='fastMl', suffix='', synResults='synResults', synMeasures='synMeasures', abSharpArgs='', runsDir='runsAb', doMeasures=False, withFocusColumn=False):
+def oneModel(dataDir='csvGeneral', dataSourceNum=0, model='fastMl', suffix='', synResults='synResults', synMeasures='synMeasures', abSharpArgs='', runsDir='runsAb', doMeasures=False, withFocusColumn=False, force=False):
     tu = testUtils.testUtilities()
     tu.registerCsvLib(dataDir)
     tu.registerSynResults(synResults)
@@ -187,7 +187,7 @@ def oneModel(dataDir='csvGeneral', dataSourceNum=0, model='fastMl', suffix='', s
         outPath = os.path.join(modelsDir, f"{sourceFileName}.json")
     else:
         outPath = os.path.join(modelsDir, f"{sourceFileName}.{focusColumn}.json")
-    if os.path.exists(outPath):
+    if not force and os.path.exists(outPath):
         print(f"Result {outPath} already exists, skipping")
         print("oneModel:SUCCESS (skipped)")
         return
@@ -207,7 +207,7 @@ def oneModel(dataDir='csvGeneral', dataSourceNum=0, model='fastMl', suffix='', s
     mls = testUtils.mlSupport(tu)
     metaData = makeMetadata(df)
     if model == 'abSharp' or 'syndiffix' in model:
-        colTypeSymbols = {'text': 's', 'real': 'r', 'datetime': 't', 'int': 'i'}
+        colTypeSymbols = {'text': 's', 'real': 'r', 'datetime': 't', 'int': 'i', 'boolean': 'b'}
         colTypes = tu.getColTypesFromDataframe(df)
         columns = []
         for colName, colType in zip(colNames, colTypes):

--- a/test_syndiffix/testUtils.py
+++ b/test_syndiffix/testUtils.py
@@ -61,7 +61,9 @@ class mlSupport:
     def getColTypes(self, df):
         colTypes = []
         for colType in df.dtypes:
-            if pd.api.types.is_integer_dtype(colType):
+            if pd.api.types.is_bool_dtype(colType):
+                colTypes.append('boolean')
+            elif pd.api.types.is_integer_dtype(colType):
                 colTypes.append('integer')
             elif pd.api.types.is_float_dtype(colType) or pd.api.types.is_numeric_dtype(colType):
                 colTypes.append('float')

--- a/test_syndiffix/testUtils.py
+++ b/test_syndiffix/testUtils.py
@@ -136,7 +136,7 @@ class testUtilities:
                 pass  # ...so leave whole column as-is unconverted
         for colType in df.dtypes:
             if pd.api.types.is_bool_dtype(colType):
-                colTypes.append('text')
+                colTypes.append('boolean')
             elif pd.api.types.is_integer_dtype(colType):
                 colTypes.append('int')
             elif pd.api.types.is_float_dtype(colType) or pd.api.types.is_numeric_dtype(colType):


### PR DESCRIPTION
Two fixes:
 - [Recognize bool dtype in makeMlClassInfo](https://github.com/diffix/test-syndiffix/commit/5fda57526e4979a95247543a8150234925301b5f) fixes the `TypeError: numpy boolean subtract, the `-` operator, is not supported, use the bitwise_xor, the `^` operator, or the logical_xor function instead.` in `fake_hotel_guests`
 - [Recognize bool dtype in SynDiffix columns specs](https://github.com/diffix/test-syndiffix/commit/48dbd716fab2fb45b3e5d20b662be7ac747be434) fixes the `TypeError: Encoders require their input to be uniformly strings or numbers. Got ['bool', 'str']` in `alarm` dataset

I'm very unsure if this isn't going to be breaking some other stuff, so please take a careful look and (for the second fix) we need to rerun the syndiffix and syndiffix_focus synthetizations to take effect.

