### PR TITLE
Paul features clusters

### DIFF
--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -339,6 +339,7 @@ def oneModel(dataDir='csvGeneral',
     colNames = list(df.columns.values)
     # quick test to make sure that the test and train data match columns
     dfTest = readCsv(testDataPath)
+    madeTempDataSource = False
     if featuresJob:
         # Remove columns not in the features set or target column
         # From here on out, we will be working with so-truncated data
@@ -404,6 +405,7 @@ def oneModel(dataDir='csvGeneral',
             tempFilesDir = os.path.join(tu.baseDir, 'tempCsvFiles')
             os.makedirs(tempFilesDir, exist_ok=True)
             dataSourcePath = os.path.join(tempFilesDir, sourceFileName)
+            madeTempDataSource = True
             df.to_csv(dataSourcePath, index=False, header=df.columns)
             print(dataSourcePath)
     print(list(dfTest.columns.values))
@@ -432,10 +434,8 @@ def oneModel(dataDir='csvGeneral',
             extraArgs = ["--clusters", f"{clusterSpecJson}"]
         elif featuresJob:
             extraArgs = ["--no-clustering"]
-        print("syndiffix args:")
-        print(abSharpArgs)
         runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob, extraArgs=extraArgs)
-        if featuresJob:
+        if madeTempDataSource:
             os.remove(dataSourcePath)
     else:
         runTest(model, metaData['sdvMetaData'], df, colNames, outPath, dataSourceNum, testData)

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -238,7 +238,7 @@ def makeClusterSpec(allColumns, featuresColumns, focusColumn, maxClusterSize):
         print(f"ERROR: bad column in allCols {allCols}")
         pp.pprint(clusterSpec)
         quit()
-    return json.dumps(clusterSpec)
+    return clusterSpec
 
 def oneModel(dataDir='csvGeneral',
              dataSourceNum=0,
@@ -352,11 +352,12 @@ def oneModel(dataDir='csvGeneral',
             if featureThreshold:
                 featuresColumns = getUniFeaturesByThreshold(featuresJob, featureThreshold)
         featuresWithoutMax = len(featuresColumns)
-        clusterSpec = None
+        clusterSpecJson = None
         if multiCluster:
             # At this point, featuresColumns are the columns that we'll want to include
             # in clusters
             clusterSpec = makeClusterSpec(origColNames, featuresColumns, focusColumn, maxClusterSize)
+            clusterSpecJson = json.dumps(clusterSpec)
             print("Cluster information:")
             print(f"All columns: {origColNames}")
             print(f"Features columns: {featuresColumns}")
@@ -392,6 +393,9 @@ def oneModel(dataDir='csvGeneral',
                 'featureThreshold':featureThreshold,
                 'usedFeatures':colNames,
                 'featuresWithoutMax':featuresWithoutMax,
+                'featureThreshold':featureThreshold,
+                'multiCluster':multiCluster,
+                'maxClusterSize':maxClusterSize,
             }
             import uuid
             sourceFileName = sourceFileName + '.' + str(uuid.uuid4()) + '.csv'
@@ -421,8 +425,8 @@ def oneModel(dataDir='csvGeneral',
             columns.append(f"{colName}:{colTypeSymbols[colType]}")
         if withFocusColumn:
             abSharpArgs += f" --clustering-maincolumn '{focusColumn}' "
-        elif clusterSpec:
-            abSharpArgs += f" --clusters {clusterSpec} "
+        elif clusterSpecJson:
+            abSharpArgs += f" --clusters {clusterSpecJson} "
         elif featuresJob:
             abSharpArgs += " --no-clustering "
         runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob)

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -246,7 +246,6 @@ def makeClusterSpec(allColumns, featuresColumns, focusColumn, maxClusterSize):
     print(f"Target column: {focusColumn}")
     print(f"Target column: {focCol}")
     pp.pprint(clusterSpec)
-    quit()
     return clusterSpec
 
 def oneModel(dataDir='csvGeneral',
@@ -426,6 +425,7 @@ def oneModel(dataDir='csvGeneral',
                 # type that absharp can handle regardless of what the value are...
                 colType = 'text'
             columns.append(f"{colName}:{colTypeSymbols[colType]}")
+        abSharpArgs += " --verbose "
         if withFocusColumn:
             abSharpArgs += f" --clustering-maincolumn '{focusColumn}' "
         elif clusterSpecJson:

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -357,7 +357,12 @@ def oneModel(dataDir='csvGeneral',
             # At this point, featuresColumns are the columns that we'll want to include
             # in clusters
             clusterSpec = makeClusterSpec(origColNames, featuresColumns, focusColumn, maxClusterSize)
-            pass
+            print("Cluster information:")
+            print(f"All columns: {origColNames}")
+            print(f"Features columns: {featuresColumns}")
+            print(f"Target column: {focusColumn}")
+            pp.pprint(clusterSpec)
+            quit()
         else:
             # We are going to limit ourselves to a single cluster, and only the
             # columns in that cluster (this is mainly test purposes)

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -18,7 +18,6 @@ from misc.csvUtils import readCsv
 
 pp = pprint.PrettyPrinter(indent=4)
 
-
 def runTest(runModel, metaData, df, colNames, outPath, dataSourceNum, testData):
     print("First row of data:")
     print(df.iloc[0])

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -238,6 +238,15 @@ def makeClusterSpec(allColumns, featuresColumns, focusColumn, maxClusterSize):
         print(f"ERROR: bad column in allCols {allCols}")
         pp.pprint(clusterSpec)
         quit()
+    print("Cluster information:")
+    print(f"All columns: {allColumns}")
+    print(f"All columns: {allCols}")
+    print(f"Features columns: {featuresColumns}")
+    print(f"Features columns: {featCols}")
+    print(f"Target column: {focusColumn}")
+    print(f"Target column: {focCol}")
+    pp.pprint(clusterSpec)
+    quit()
     return clusterSpec
 
 def oneModel(dataDir='csvGeneral',
@@ -358,12 +367,6 @@ def oneModel(dataDir='csvGeneral',
             # in clusters
             clusterSpec = makeClusterSpec(origColNames, featuresColumns, focusColumn, maxClusterSize)
             clusterSpecJson = json.dumps(clusterSpec)
-            print("Cluster information:")
-            print(f"All columns: {origColNames}")
-            print(f"Features columns: {featuresColumns}")
-            print(f"Target column: {focusColumn}")
-            pp.pprint(clusterSpec)
-            quit()
         else:
             # We are going to limit ourselves to a single cluster, and only the
             # columns in that cluster (this is mainly test purposes)

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -432,6 +432,8 @@ def oneModel(dataDir='csvGeneral',
             abSharpArgs += f" --clusters {clusterSpecJson} "
         elif featuresJob:
             abSharpArgs += " --no-clustering "
+        print("syndiffix args:")
+        print(abSharpArgs)
         runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob)
         if featuresJob:
             os.remove(dataSourcePath)

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -71,7 +71,7 @@ def runTest(runModel, metaData, df, colNames, outPath, dataSourceNum, testData):
         json.dump(outJson, f, indent=4)
 
 
-def runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob):
+def runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob, extraArgs=[]):
     thisDir = os.path.dirname(os.path.abspath(__file__))
     abSharpDir = os.path.join(tu.abSharpDir, 'src', 'SynDiffix.Debug')
 
@@ -79,7 +79,7 @@ def runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, t
     print(f"cmd-line args: {abSharpArgs}")
 
     abSharp = subprocess.run(
-        ['dotnet', 'run', '--configuration', 'Release', dataSourcePath, '--columns', *columns, *abSharpArgs],
+        ['dotnet', 'run', '--configuration', 'Release', dataSourcePath, '--columns', *columns, *abSharpArgs, *extraArgs],
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
         cwd=abSharpDir,
@@ -425,16 +425,16 @@ def oneModel(dataDir='csvGeneral',
                 # type that absharp can handle regardless of what the value are...
                 colType = 'text'
             columns.append(f"{colName}:{colTypeSymbols[colType]}")
-        abSharpArgs += " --verbose "
+        extraArgs = []
         if withFocusColumn:
-            abSharpArgs += f" --clustering-maincolumn '{focusColumn}' "
+            extraArgs = ["--clustering-maincolumn", f"'{focusColumn}'"]
         elif clusterSpecJson:
-            abSharpArgs += f" --clusters {clusterSpecJson} "
+            extraArgs = ["--clusters", f"{clusterSpecJson}"]
         elif featuresJob:
-            abSharpArgs += " --no-clustering "
+            extraArgs = ["--no-clustering"]
         print("syndiffix args:")
         print(abSharpArgs)
-        runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob)
+        runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob, extraArgs=extraArgs)
         if featuresJob:
             os.remove(dataSourcePath)
     else:

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -429,7 +429,7 @@ def oneModel(dataDir='csvGeneral',
             columns.append(f"{colName}:{colTypeSymbols[colType]}")
         extraArgs = []
         if withFocusColumn:
-            extraArgs = ["--clustering-maincolumn", f"'{focusColumn}'"]
+            extraArgs = ["--clustering-maincolumn", f"{focusColumn}"]
         elif clusterSpecJson:
             extraArgs = ["--clusters", f"{clusterSpecJson}"]
         elif featuresJob:

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -185,6 +185,61 @@ def getUniFeaturesByThreshold(featuresJob, featureThreshold):
             break
     return features
 
+def makeClusterSpec(allColumns, featuresColumns, focusColumn, maxClusterSize):
+    '''
+    { "InitialCluster": [4, 5, 7],
+      "DerivedClusters": [
+        { "StitchColumns": [7], "DerivedColumns": [1, 3, 9] },
+        { "StitchColumns": [9, 1], "DerivedColumns": [8, 0] },
+        { "StitchColumns": [1, 9], "DerivedColumns": [2] },
+        { "StitchColumns": [7, 3], "DerivedColumns": [6] }
+      ] }
+    '''
+    featCols = []
+    for column in featuresColumns:
+        featCols.append(allColumns.index(column))
+    focCol = allColumns.index(focusColumn)
+    cSize = maxClusterSize-1
+    # featCols is featuresColumns indices, focCol is focusColumn index
+    initialCluster = featCols[:cSize]
+    initialCluster += [focCol]
+    remainCols = featCols[cSize:]
+    clusterSpec = {'InitialCluster':initialCluster, 'DerivedClusters':[]}
+    # Add the clusters
+    while len(remainCols) > 0:
+        derivedCols = remainCols[:cSize]
+        clusterSpec['DerivedClusters'].append({'StitchColumns':[focCol],
+                                               'DerivedColumns':derivedCols})
+        remainCols = remainCols[cSize:]
+    # Add the patch columns
+    allCols = []
+    for column in allColumns:
+        allCols.append(allColumns.index(column))
+    for column in allCols:
+        if column in featCols or column == focCol:
+            continue
+        clusterSpec['DerivedClusters'].append({'StitchColumns':[],
+                                               'DerivedColumns':[column]})
+    # Let's check things:
+    for column in clusterSpec['InitialCluster']:
+        if column not in allCols:
+            print(f"ERROR: bad column in initialCluster")
+            pp.pprint(clusterSpec)
+            quit()
+        allCols.remove(column)
+    for derived in clusterSpec['DerivedClusters']:
+        for column in derived['DerivedColumns']:
+            if column not in allCols:
+                print(f"ERROR: bad column in derivedCluster {derived}")
+                pp.pprint(clusterSpec)
+                quit()
+            allCols.remove(column)
+    if len(allCols) > 0:
+        print(f"ERROR: bad column in allCols {allCols}")
+        pp.pprint(clusterSpec)
+        quit()
+    return json.dumps(clusterSpec)
+
 def oneModel(dataDir='csvGeneral',
              dataSourceNum=0,
              model='fastMl',
@@ -200,6 +255,8 @@ def oneModel(dataDir='csvGeneral',
              numFeatures=None,
              maxFeatures=6,
              featureThreshold=None,
+             multiCluster=False,
+             maxClusterSize=3,
              force=False):
     tu = testUtils.testUtilities()
     tu.registerCsvLib(dataDir)
@@ -295,40 +352,49 @@ def oneModel(dataDir='csvGeneral',
             if featureThreshold:
                 featuresColumns = getUniFeaturesByThreshold(featuresJob, featureThreshold)
         featuresWithoutMax = len(featuresColumns)
-        if 'fixed' not in featuresJob and len(featuresColumns) > maxFeatures:
-            print(f"Truncating to {maxFeatures} features due to maxFeatures")
-            featuresColumns = featuresColumns[:maxFeatures-1]
-        print("Feature columns")
-        print(featuresColumns)
-        newColNames = featuresColumns + [featuresJob['targetColumn']]
-        if len(newColNames) != len(list(set(newColNames))):
-            print(f"ERROR: duplicates in newColNames {newColNames}")
-            quit()
-        for origCol in origColNames:
-            if origCol not in newColNames:
-                df.drop(origCol, axis=1, inplace=True)
-                dfTest.drop(origCol, axis=1, inplace=True)
-        # Now we need to make a csv out of df to later give to abSharp
-        print("columns in dfTest")
-        print(dfTest.columns)
-        print("columns in df")
-        print(df.columns)
-        colNames = list(df.columns.values)
-        print("New columns")
-        print(colNames)
-        featuresJob['params'] = {
-            'maxFeatures':maxFeatures,
-            'featureThreshold':featureThreshold,
-            'usedFeatures':colNames,
-            'featuresWithoutMax':featuresWithoutMax,
-        }
-        import uuid
-        sourceFileName = sourceFileName + '.' + str(uuid.uuid4()) + '.csv'
-        tempFilesDir = os.path.join(tu.baseDir, 'tempCsvFiles')
-        os.makedirs(tempFilesDir, exist_ok=True)
-        dataSourcePath = os.path.join(tempFilesDir, sourceFileName)
-        df.to_csv(dataSourcePath, index=False, header=df.columns)
-        print(dataSourcePath)
+        clusterSpec = None
+        if multiCluster:
+            # At this point, featuresColumns are the columns that we'll want to include
+            # in clusters
+            clusterSpec = makeClusterSpec(origColNames, featuresColumns, focusColumn, maxClusterSize)
+            pass
+        else:
+            # We are going to limit ourselves to a single cluster, and only the
+            # columns in that cluster (this is mainly test purposes)
+            if 'fixed' not in featuresJob and len(featuresColumns) > maxFeatures:
+                print(f"Truncating to {maxFeatures} features due to maxFeatures")
+                featuresColumns = featuresColumns[:maxFeatures-1]
+            print("Feature columns")
+            print(featuresColumns)
+            newColNames = featuresColumns + [featuresJob['targetColumn']]
+            if len(newColNames) != len(list(set(newColNames))):
+                print(f"ERROR: duplicates in newColNames {newColNames}")
+                quit()
+            for origCol in origColNames:
+                if origCol not in newColNames:
+                    df.drop(origCol, axis=1, inplace=True)
+                    dfTest.drop(origCol, axis=1, inplace=True)
+            # Now we need to make a csv out of df to later give to abSharp
+            print("columns in dfTest")
+            print(dfTest.columns)
+            print("columns in df")
+            print(df.columns)
+            colNames = list(df.columns.values)
+            print("New columns")
+            print(colNames)
+            featuresJob['params'] = {
+                'maxFeatures':maxFeatures,
+                'featureThreshold':featureThreshold,
+                'usedFeatures':colNames,
+                'featuresWithoutMax':featuresWithoutMax,
+            }
+            import uuid
+            sourceFileName = sourceFileName + '.' + str(uuid.uuid4()) + '.csv'
+            tempFilesDir = os.path.join(tu.baseDir, 'tempCsvFiles')
+            os.makedirs(tempFilesDir, exist_ok=True)
+            dataSourcePath = os.path.join(tempFilesDir, sourceFileName)
+            df.to_csv(dataSourcePath, index=False, header=df.columns)
+            print(dataSourcePath)
     print(list(dfTest.columns.values))
     if colNames != list(dfTest.columns.values):
         print(f("ERROR: Train column names {colNames} don't match test column names {list(dfTest.columns.values)}"))
@@ -350,6 +416,8 @@ def oneModel(dataDir='csvGeneral',
             columns.append(f"{colName}:{colTypeSymbols[colType]}")
         if withFocusColumn:
             abSharpArgs += f" --clustering-maincolumn '{focusColumn}' "
+        elif clusterSpec:
+            abSharpArgs += f" --clusters {clusterSpec} "
         elif featuresJob:
             abSharpArgs += " --no-clustering "
         runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob)

--- a/test_syndiffix/oneModel.py
+++ b/test_syndiffix/oneModel.py
@@ -428,9 +428,9 @@ def oneModel(dataDir='csvGeneral',
             columns.append(f"{colName}:{colTypeSymbols[colType]}")
         extraArgs = []
         if withFocusColumn:
-            extraArgs = ["--clustering-maincolumn", f"{focusColumn}"]
+            extraArgs = ["--clustering-maincolumn", focusColumn]
         elif clusterSpecJson:
-            extraArgs = ["--clusters", f"{clusterSpecJson}"]
+            extraArgs = ["--clusters", clusterSpecJson]
         elif featuresJob:
             extraArgs = ["--no-clustering"]
         runAbSharp(tu, dataSourcePath, outPath, abSharpArgs, columns, focusColumn, testData, featuresJob, extraArgs=extraArgs)


### PR DESCRIPTION
@edongashi I'm having trouble with the command line arguments to absharp.

Please see the code at line 428-437 in `oneModel.py`. It appears to be taking the cluster json string and breaking up at every space. I'm not sure what I should be doing...

```
cmd-line args: ['--verbose', '--clusters', '{InitialCluster:', '[28,', '6,', '0,', '1],', 'DerivedClusters:', '[{StitchColumns:', '[1],', 'DerivedColumns:', '[4,', '29,', '9]},', '{StitchColumns:', '[1],', 'DerivedColumns:', '[27,', '3,', '20]},', '{StitchColumns:', '[1],', 'DerivedColumns:', '[5,', '26,', '15]},', '{StitchColumns:', '[1],', 'DerivedColumns:', '[21,', '11,', '2]},', '{StitchColumns:', '[1],', 'DerivedColumns:', '[24,', '8,', '13]},', '{StitchColumns:', '[1],', 'DerivedColumns:', '[25,', '14]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[7]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[10]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[12]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[16]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[17]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[18]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[19]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[22]},', '{StitchColumns:', '[],', 'DerivedColumns:', '[23]}]}']
```
